### PR TITLE
Remove gox in favor of go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@ GO_CMD?=go
 CGO_ENABLED?=0
 TOOL?=vault-plugin-secrets-terraform
 TEST?=$$($(GO_CMD) list ./... | grep -v /vendor/ | grep -v /integ)
-EXTERNAL_TOOLS=\
-	github.com/mitchellh/gox
+EXTERNAL_TOOLS=
 BUILD_TAGS?=${TOOL}
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ disclose_ by contacting us at
 - [Vault Website](https://www.vaultproject.io)
 - [Terraform Cloud](https://www.terraform.io/cloud)
 - [Terraform Cloud Secrets
-  Docs](https://www.vaultproject.io/docs/secrets/terraform/index.html)
+  Docs](https://developer.hashicorp.com/vault/docs/secrets/terraform)
 - [Terraform Cloud API token
   documentation](https://www.terraform.io/docs/cloud/users-teams-organizations/api-tokens.html)
 - [Vault Github Project](https://www.github.com/hashicorp/vault)
@@ -26,20 +26,20 @@ disclose_ by contacting us at
 ## Getting Started
 
 This is a [Vault
-plugin](https://www.vaultproject.io/docs/internals/plugins.html) and is meant to
+plugin](https://developer.hashicorp.com/vault/docs/plugins) and is meant to
 work with Vault. This guide assumes you have already installed Vault and have a
 basic understanding of how Vault works.
 
 Otherwise, first read this guide on how to [get started with
-Vault](https://www.vaultproject.io/intro/getting-started/install.html).
+Vault](https://developer.hashicorp.com/vault/tutorials/getting-started/getting-started-install).
 
 To learn specifically about how plugins work, see documentation on [Vault
-plugins](https://www.vaultproject.io/docs/internals/plugins.html).
+plugins](https://developer.hashicorp.com/vault/docs/plugins).
 
 ## Usage
 
 Please see [documentation for the
-plugin](https://www.vaultproject.io/docs/secrets/terraform/index.html) on the
+plugin](https://developer.hashicorp.com/vault/docs/secrets/terraform) on the
 Vault website.
 
 This plugin is currently built into Vault and by default is accessed at
@@ -61,12 +61,6 @@ For local dev first make sure Go is properly installed, including
 setting up a [GOPATH](https://golang.org/doc/code.html#GOPATH).
 Next, clone this repository into
 `$GOPATH/src/github.com/hashicorp/vault-plugin-secrets-terraform`.
-You can then download any required build tools by bootstrapping your
-environment:
-
-```sh
-$ make bootstrap
-```
 
 To compile a development version of this plugin, run `make` or `make dev`.
 This will put the plugin binary in the `bin` and `$GOPATH/bin` folders. `dev`
@@ -79,13 +73,11 @@ $ make dev
 
 Put the plugin binary into a location of your choice. This directory will be
 specified as the
-[`plugin_directory`](https://www.vaultproject.io/docs/configuration/index.html#plugin_directory)
+[`plugin_directory`](https://developer.hashicorp.com/vault/docs/configuration#plugin_directory)
 in the Vault config used to start the server.
 
-```json
-...
+```hcl
 plugin_directory = "path/to/plugin/directory"
-...
 ```
 
 Start a Vault server with this config file:
@@ -95,7 +87,7 @@ $ vault server -config=path/to/config.json ...
 ```
 
 Once the server is started, register the plugin in the Vault server's [plugin
-catalog](https://www.vaultproject.io/docs/internals/plugins.html#plugin-catalog):
+catalog](https://developer.hashicorp.com/vault/docs/plugins/plugin-architecture#plugin-catalog):
 
 ```sh
 $ vault write sys/plugins/catalog/terraform \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,6 +8,8 @@ TOOL=vault-plugin-secrets-terraform
 # This script builds the application from source for multiple platforms.
 set -e
 
+GO_CMD=${GO_CMD:-go}
+
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
@@ -23,11 +25,6 @@ BUILD_TAGS="${BUILD_TAGS}:-${TOOL}"
 GIT_COMMIT="$(git rev-parse HEAD)"
 GIT_DIRTY="$(test -n "$(git status --porcelain)" && echo "+CHANGES" || true)"
 
-# Determine the arch/os combos we're building for
-XC_ARCH=${XC_ARCH:-"386 amd64"}
-XC_OS=${XC_OS:-linux darwin windows freebsd openbsd netbsd solaris}
-XC_OSARCH=${XC_OSARCH:-"linux/386 linux/amd64 linux/arm linux/arm64 darwin/386 darwin/amd64 windows/386 windows/amd64 freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 openbsd/arm netbsd/386 netbsd/amd64 netbsd/arm solaris/amd64"}
-
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in
     CYGWIN*)
@@ -41,52 +38,23 @@ rm -f bin/*
 rm -rf pkg/*
 mkdir -p bin/
 
-# If its dev mode, only build for our self
-if [ "${VAULT_DEV_BUILD}x" != "x" ]; then
-    XC_OS=$(go env GOOS)
-    XC_ARCH=$(go env GOARCH)
-    XC_OSARCH=$(go env GOOS)/$(go env GOARCH)
-fi
-
-# The main method we need for building is in the cmd directory
-cd "${DIR}/cmd/${TOOL}"
 
 # Build!
 echo "==> Building..."
-gox \
-    -osarch="${XC_OSARCH}" \
+${GO_CMD} build \
+    -gcflags "${GCFLAGS}" \
     -ldflags "-X github.com/hashicorp/${TOOL}/version.GitCommit='${GIT_COMMIT}${GIT_DIRTY}'" \
-    -output "${DIR}/pkg/{{.OS}}_{{.Arch}}/${TOOL}" \
-    -tags="${BUILD_TAGS}" \
-    .
-
-# Return to the home directory
-cd "$DIR"
+    -o "bin/${TOOL}" \
+    -tags "${BUILD_TAGS}" \
+    "${DIR}/cmd/${TOOL}"
 
 # Move all the compiled things to the $GOPATH/bin
 OLDIFS=$IFS
 IFS=: MAIN_GOPATH=($GOPATH)
 IFS=$OLDIFS
 
-# Copy our OS/Arch to the bin/ directory
-DEV_PLATFORM="./pkg/$(go env GOOS)_$(go env GOARCH)"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
-
-if [ "${VAULT_DEV_BUILD}x" = "x" ]; then
-    # Zip and copy to the dist dir
-    echo "==> Packaging..."
-    for PLATFORM in $(find ./pkg -mindepth 1 -maxdepth 1 -type d); do
-        OSARCH=$(basename ${PLATFORM})
-        echo "--> ${OSARCH}"
-
-        pushd $PLATFORM >/dev/null 2>&1
-        zip ../${OSARCH}.zip ./*
-        popd >/dev/null 2>&1
-    done
-fi
+rm -f ${MAIN_GOPATH}/bin/${TOOL}
+cp bin/${TOOL} ${MAIN_GOPATH}/bin/
 
 # Done!
 echo


### PR DESCRIPTION
gox is no longer maintained and releases are done with `go build` now. See https://github.com/hashicorp/vault/pull/16353 where we removed gox in Vault.