### PR TITLE
include description field for user tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+FEATURES:
+* Added optional description for user token roles to provide a description in HCPTF UI: https://github.com/hashicorp/vault-plugin-secrets-terraform/pull/84
+
 ## 0.11.0
 ### FEb 7, 2025
 IMPROVEMENTS:

--- a/backend_test.go
+++ b/backend_test.go
@@ -45,6 +45,7 @@ type testEnv struct {
 	Organization string
 	TeamID       string
 	UserID       string
+	Description  string
 
 	Backend logical.Backend
 	Context context.Context
@@ -160,7 +161,8 @@ func (e *testEnv) AddUserTokenRole(t *testing.T) {
 		Path:      "role/test-user-token",
 		Storage:   e.Storage,
 		Data: map[string]interface{}{
-			"user_id": e.UserID,
+			"user_id":     e.UserID,
+			"description": e.Description,
 		},
 	}
 	resp, err := e.Backend.HandleRequest(e.Context, req)

--- a/path_roles.go
+++ b/path_roles.go
@@ -18,6 +18,7 @@ type terraformRoleEntry struct {
 	Organization string        `json:"organization,omitempty"`
 	TeamID       string        `json:"team_id,omitempty"`
 	UserID       string        `json:"user_id,omitempty"`
+	Description  string        `json:"description,omitempty"`
 	TTL          time.Duration `json:"ttl"`
 	MaxTTL       time.Duration `json:"max_ttl"`
 	Token        string        `json:"token,omitempty"`
@@ -29,6 +30,9 @@ func (r *terraformRoleEntry) toResponseData() map[string]interface{} {
 		"name":    r.Name,
 		"ttl":     r.TTL.Seconds(),
 		"max_ttl": r.MaxTTL.Seconds(),
+	}
+	if r.Description != "" {
+		respData["description"] = r.Description
 	}
 	if r.Organization != "" {
 		respData["organization"] = r.Organization
@@ -57,6 +61,10 @@ func pathRole(b *tfBackend) []*framework.Path {
 					Type:        framework.TypeLowerCaseString,
 					Description: "Name of the role",
 					Required:    true,
+				},
+				"description": {
+					Type:        framework.TypeString,
+					Description: "Description of the token created by the role",
 				},
 				"organization": {
 					Type:        framework.TypeString,
@@ -164,6 +172,10 @@ func (b *tfBackend) pathRolesWrite(ctx context.Context, req *logical.Request, d 
 
 	if userID, ok := d.GetOk("user_id"); ok {
 		roleEntry.UserID = userID.(string)
+	}
+
+	if description, ok := d.GetOk("description"); ok {
+		roleEntry.Description = description.(string)
 	}
 
 	if roleEntry.UserID != "" && (roleEntry.Organization != "" || roleEntry.TeamID != "") {

--- a/path_roles_test.go
+++ b/path_roles_test.go
@@ -134,6 +134,8 @@ func TestUserRole(t *testing.T) {
 	organization := checkEnvVars(t, envVarTerraformOrganization)
 	teamID := checkEnvVars(t, envVarTerraformTeamID)
 	userID := checkEnvVars(t, envVarTerraformUserID)
+	descriptionOriginal := "description1"
+	descriptionUpdated := "description2"
 
 	t.Run("Create User Role - fail", func(t *testing.T) {
 		resp, err := testTokenRoleCreate(t, b, s, roleName, map[string]interface{}{
@@ -147,8 +149,9 @@ func TestUserRole(t *testing.T) {
 	})
 	t.Run("Create User Role - pass", func(t *testing.T) {
 		resp, err := testTokenRoleCreate(t, b, s, roleName, map[string]interface{}{
-			"user_id": userID,
-			"max_ttl": "3600",
+			"user_id":     userID,
+			"max_ttl":     "3600",
+			"description": descriptionOriginal,
 		})
 
 		require.Nil(t, err)
@@ -162,11 +165,13 @@ func TestUserRole(t *testing.T) {
 		require.Nil(t, resp.Error())
 		require.NotNil(t, resp)
 		require.Equal(t, resp.Data["user_id"], userID)
+		require.Equal(t, resp.Data["description"], descriptionOriginal)
 	})
 	t.Run("Update User Role", func(t *testing.T) {
 		resp, err := testTokenRoleUpdate(t, b, s, map[string]interface{}{
-			"ttl":     "1m",
-			"max_ttl": "5h",
+			"ttl":         "1m",
+			"max_ttl":     "5h",
+			"description": descriptionUpdated,
 		})
 
 		require.Nil(t, err)
@@ -180,6 +185,7 @@ func TestUserRole(t *testing.T) {
 		require.Nil(t, resp.Error())
 		require.NotNil(t, resp)
 		require.Equal(t, resp.Data["user_id"], userID)
+		require.Equal(t, resp.Data["description"], descriptionUpdated)
 	})
 }
 

--- a/terraform_token.go
+++ b/terraform_token.go
@@ -59,8 +59,10 @@ func createTeamToken(ctx context.Context, c *client, teamID string) (*terraformT
 	}, nil
 }
 
-func createUserToken(ctx context.Context, c *client, userID string) (*terraformToken, error) {
-	token, err := c.UserTokens.Create(ctx, userID, tfe.UserTokenCreateOptions{})
+func createUserToken(ctx context.Context, c *client, userID string, description string) (*terraformToken, error) {
+	token, err := c.UserTokens.Create(ctx, userID, tfe.UserTokenCreateOptions{
+		Description: description,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
closes: #83 

Description is not supported by Org or Team tokens. Only implemented for user tokens 

```shell
CGO_ENABLED=0 VAULT_TOKEN= VAULT_ACC=1 go test -v -tags='vault-plugin-secrets-terraform' $(go list ./... | grep -v /vendor/ | grep -v /integ) --run=TestUserRole -count=1 -timeout=10m -parallel=4
?   	github.com/hashicorp/vault-plugin-secrets-terraform/cmd/vault-plugin-secrets-terraform	[no test files]
=== RUN   TestUserRole
=== RUN   TestUserRole/Create_User_Role_-_fail
=== RUN   TestUserRole/Create_User_Role_-_pass
=== RUN   TestUserRole/Read_User_Role
=== RUN   TestUserRole/Update_User_Role
=== RUN   TestUserRole/Re-read_User_Role
--- PASS: TestUserRole (0.00s)
    --- PASS: TestUserRole/Create_User_Role_-_fail (0.00s)
    --- PASS: TestUserRole/Create_User_Role_-_pass (0.00s)
    --- PASS: TestUserRole/Read_User_Role (0.00s)
    --- PASS: TestUserRole/Update_User_Role (0.00s)
    --- PASS: TestUserRole/Re-read_User_Role (0.00s)
PASS
ok  	github.com/hashicorp/vault-plugin-secrets-terraform	0.264s
```

running tests locally:
```shell
$ vault write sys/plugins/catalog/terraform sha256="414b412a4f024195d4585c1942be9ea8354c281eaeb0ed72ab318477a9d80793" command="vault-plugin-secrets-terraform"
$ vault secrets enable -plugin-name='terraform' plugin
$ vault write terraform/config token=$TFE_TOKEN
$ vault write terraform/role/tfc-mgmt user_id=user-<redacted> ttl=7200 description="test description"
$ vault read terraform/role/tfc-mgmt
Key            Value
---            -----
description    test description
max_ttl        0s
name           tfc-mgmt
ttl            2h
user_id        user-<redacted>
```

<img width="637" alt="Screenshot 2025-03-10 at 4 05 29 PM" src="https://github.com/user-attachments/assets/57a409d1-3e46-45e3-bf7d-7189531b5b8d" />

