### PR TITLE
[CHANGELOG] Prepare for v0.13.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.13.0
+### October 2, 2025
+
+* update deps and go version (#100)
+* Automated dependency upgrades (#82)
+* [COMPLIANCE] Add Copyright and License Headers (#99)
+* init changie (#98)
+* Add backport assistant workflow (#97)
+* Fix user token issue related to credential type (#95)
+* Add backport assistant workflow (#94)
+* [Compliance] - PR Template Changes Required (#93)
+
 ## 0.12.0
 ### Jun 6, 2025
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.13.0
 ### October 2, 2025
 
-* update deps and go version (#100)
+* Bump go version to 1.25.1 (#100)
 * Automated dependency upgrades (#82)
 * [COMPLIANCE] Add Copyright and License Headers (#99)
 * init changie (#98)


### PR DESCRIPTION
Changelog update for version [v0.13.0](https://github.com/hashicorp/vault-plugin-secrets-terraform/releases/tag/v0.13.0).

---
_This PR was generated by an automated workflow._

Full log: https://github.com/hashicorp/vault-plugin-release/actions/runs/18204947810

