### PR TITLE
VAULT-48786: add metadata field to Terraform Cloud SE role

### DIFF
--- a/metadata_helpers.go
+++ b/metadata_helpers.go
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. 2020, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package tfc
+
+import "fmt"
+
+// toStringMap converts map[string]interface{} to map[string]string.
+// Returns an error if any value is not a string.
+func toStringMap(raw interface{}) (map[string]string, error) {
+	if raw == nil {
+		return make(map[string]string), nil
+	}
+	rawMap, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected map[string]interface{}, got %T", raw)
+	}
+	result := make(map[string]string, len(rawMap))
+	for k, v := range rawMap {
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("metadata value for key %q must be a string, got %T", k, v)
+		}
+		result[k] = s
+	}
+	return result, nil
+}

--- a/path_roles.go
+++ b/path_roles.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-secure-stdlib/strutil"
 	"github.com/hashicorp/vault/sdk/framework"
+	"github.com/hashicorp/vault/sdk/helper/custommetadata"
 	"github.com/hashicorp/vault/sdk/logical"
 )
 
@@ -31,23 +32,25 @@ func credentialType_Values() []string {
 
 // terraformRoleEntry is a Vault role construct that maps to TFC/TFE
 type terraformRoleEntry struct {
-	Name           string        `json:"name"`
-	Organization   string        `json:"organization,omitempty"`
-	TeamID         string        `json:"team_id,omitempty"`
-	UserID         string        `json:"user_id,omitempty"`
-	Description    string        `json:"description,omitempty"`
-	TTL            time.Duration `json:"ttl"`
-	MaxTTL         time.Duration `json:"max_ttl"`
-	CredentialType string        `json:"credential_type,omitempty"`
-	Token          string        `json:"token,omitempty"`
-	TokenID        string        `json:"token_id,omitempty"`
+	Name           string            `json:"name"`
+	Organization   string            `json:"organization,omitempty"`
+	TeamID         string            `json:"team_id,omitempty"`
+	UserID         string            `json:"user_id,omitempty"`
+	Description    string            `json:"description,omitempty"`
+	TTL            time.Duration     `json:"ttl"`
+	MaxTTL         time.Duration     `json:"max_ttl"`
+	CredentialType string            `json:"credential_type,omitempty"`
+	Token          string            `json:"token,omitempty"`
+	TokenID        string            `json:"token_id,omitempty"`
+	Metadata       map[string]string `json:"metadata"`
 }
 
 func (r *terraformRoleEntry) toResponseData() map[string]interface{} {
 	respData := map[string]interface{}{
-		"name":    r.Name,
-		"ttl":     r.TTL.Seconds(),
-		"max_ttl": r.MaxTTL.Seconds(),
+		"name":     r.Name,
+		"ttl":      r.TTL.Seconds(),
+		"max_ttl":  r.MaxTTL.Seconds(),
+		"metadata": r.Metadata,
 	}
 	if r.Description != "" {
 		respData["description"] = r.Description
@@ -118,6 +121,11 @@ func pathRole(b *tfBackend) []*framework.Path {
 				"credential_type": {
 					Type:        framework.TypeString,
 					Description: "Credential type to be used for the token. Can be either 'user', 'org', 'team', or 'team_legacy'(deprecated).",
+				},
+				"metadata": {
+					Type:        framework.TypeMap,
+					Description: "A map of string key-value pairs to associate with the role.",
+					Required:    false,
 				},
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
@@ -247,6 +255,20 @@ func (b *tfBackend) pathRolesWrite(ctx context.Context, req *logical.Request, d 
 
 	if roleEntry.MaxTTL != 0 && roleEntry.TTL > roleEntry.MaxTTL {
 		return logical.ErrorResponse("ttl cannot be greater than max_ttl"), nil
+	}
+
+	if rawMeta, ok := d.GetOk("metadata"); ok {
+		cm, err := toStringMap(rawMeta)
+		if err != nil {
+			return logical.ErrorResponse("error parsing metadata: %s", err.Error()), nil
+		}
+		if err := custommetadata.Validate(cm); err != nil {
+			return logical.ErrorResponse(err.Error()), nil
+		}
+		roleEntry.Metadata = cm
+	}
+	if roleEntry.Metadata == nil {
+		roleEntry.Metadata = make(map[string]string)
 	}
 
 	if roleEntry.CredentialType == teamLegacyCredentialType {


### PR DESCRIPTION
## Summary

Adds a `metadata` field (`map[string]string`) to the Terraform Cloud/Enterprise secrets engine `terraformRoleEntry` struct, as part of the cross-engine custom metadata initiative (VAULT-48786).

## Changes

- `path_roles.go`: add `Metadata map[string]string` to `terraformRoleEntry` (no `omitempty`); register `metadata` as `TypeMap` optional field in `pathRole()`; wire `toStringMap` + `custommetadata.Validate` in `pathRolesWrite` before `setRole`; expose `metadata` in `toResponseData()`
- `metadata_helpers.go`: package-local `toStringMap` helper (converts `map[string]interface{}` → `map[string]string`)

## Behaviour

- **Create/update with metadata present:** full-replace semantics (PUT). Validated against `sdk/helper/custommetadata` limits (64 keys, 128-char key, 512-char value).
- **Update with metadata absent:** unchanged (read-before-write via `b.getRole` already in `pathRolesWrite`).
- **Validation failure:** returns `logical.ErrorResponse` before `storage.Put`.

## Test

```
vault secrets enable terraform
vault write terraform/roles/my-role \
  organization=my-org \
  metadata="env=prod" "team=platform"
vault read terraform/roles/my-role
```